### PR TITLE
grate typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Extra Extra Small publish/subscribe micro-framework in JavaScript
 
 ## JavaScript
-It's only 182 bytes of gzipped JavaScript and it works grate, read the [documentation](http://dciccale.github.com/xxspubsub) and try it yourself.
+It's only 182 bytes of gzipped JavaScript and it works great, read the [documentation](http://dciccale.github.com/xxspubsub) and try it yourself.
 
 ## jQuery version
 If your project use jQuery, use this version of XXSPubSub, is the smallest posible pubsub done with jQuery, it's only 111 bytes gzipped!


### PR DESCRIPTION
I changed 'grate' to 'great'. Cool library!
